### PR TITLE
fix definition for Init_Machine

### DIFF
--- a/interp/machine.h
+++ b/interp/machine.h
@@ -15,7 +15,7 @@ typedef struct
     int32_t IVEC;       // Address if the Interrupt Vector Table
 } Machine_State;
 
-void Init_Machine();
+void Init_Machine(int mem_size);
 void Get_Machine_State(Machine_State *cpu);
 void Set_Machine_State(Machine_State *cpu);
 void Machine_Execute();


### PR DESCRIPTION
Declaration for Init_Machine in machine.h does not match definition in machine.c.
Declaration updated to match arguments used in stackl.c.
For some reason this is not an issue when compiling as C code, but is a compiler error when compiling as C++