### PR TITLE
Jacob asmuth fix init machine

### DIFF
--- a/interp/Makefile
+++ b/interp/Makefile
@@ -1,4 +1,4 @@
-COPTS=-Wall -g -c  -O0 -pthread -fpermissive
+COPTS=-Wall -g -c  -O0 -pthread
 COPTS2=-Wall -g -c -O0 -Wno-deprecated-declarations -pthread
 OBJS=stackl.o \
 	 opcodes.o \
@@ -30,8 +30,8 @@ opcode_defs.h: slasm
 	./slasm -defs
 
 stackl: $(OBJS)
-	g++ $(OBJS) -o stackl -lpthread -fpermissive
+	g++ $(OBJS) -o stackl -lpthread
 
 slasm: slasm.c formatstr.o
-	g++ -g -O0 slasm.c -o slasm formatstr.o -fpermissive
+	g++ -g -O0 slasm.c -o slasm formatstr.o
 

--- a/interp/Makefile
+++ b/interp/Makefile
@@ -1,4 +1,4 @@
-COPTS=-Wall -g -c  -O0 -pthread
+COPTS=-Wall -g -c  -O0 -pthread -fpermissive
 COPTS2=-Wall -g -c -O0 -Wno-deprecated-declarations -pthread
 OBJS=stackl.o \
 	 opcodes.o \
@@ -24,14 +24,14 @@ clean:
 opcodes.o: opcodes.c opcode_defs.h
 
 .c.o: 
-	gcc $(COPTS) $< -o $@
+	g++ $(COPTS) $< -o $@
 
 opcode_defs.h: slasm
 	./slasm -defs
 
 stackl: $(OBJS)
-	gcc $(OBJS) -o stackl -lpthread
+	g++ $(OBJS) -o stackl -lpthread -fpermissive
 
 slasm: slasm.c formatstr.o
-	gcc -g -O0 slasm.c -o slasm formatstr.o
+	g++ -g -O0 slasm.c -o slasm formatstr.o -fpermissive
 

--- a/interp/dma_term.c
+++ b/interp/dma_term.c
@@ -101,7 +101,7 @@ static void set_word(int32_t id, int32_t addr, int32_t value)
         Command = value;
         if (Command & DMA_T_CMD_START_WRITE)
         {
-            char *buffer = Abs_Get_Addr(Address);
+            char *buffer = (char*)Abs_Get_Addr(Address);
             if (buffer == NULL) Machine_Check("DMA_T write from invalid address");
             printf("%s", buffer);
             Status &= ~(DMA_T_STATUS_WRITE_BUSY | DMA_T_STATUS_WRITE_ERROR);

--- a/interp/opcodes.c
+++ b/interp/opcodes.c
@@ -65,7 +65,7 @@ static int32_t pop(Machine_State *cpu)
     return Get_Word(cpu, cpu->SP);
 }
 //***********************************
-void check_priv(Machine_State *cpu, char *inst_name)
+void check_priv(Machine_State *cpu, const char *inst_name)
 {
     if (cpu->FLAG & FL_USER_MODE)
     {

--- a/interp/slasm.c
+++ b/interp/slasm.c
@@ -31,7 +31,7 @@ static const char *HELP_STR =
 
 typedef struct
 {
-    char *op_name;
+    const char *op_name;
     int  num_params;
 } opcode_t;
 
@@ -111,12 +111,12 @@ static int g_Num_Label_Refs = 0;
 static int g_Label_Defs_Extent = 0;
 static int g_Label_Refs_Extent = 0;
 
-static void add_label_def(char *label)
+static void add_label_def(const char *label)
 {
     if (g_Num_Label_Defs >= g_Label_Defs_Extent)
     {
         g_Label_Defs_Extent += 50;
-        g_Label_Defs = realloc(g_Label_Defs, 
+        g_Label_Defs = (label_def_t*)realloc(g_Label_Defs, 
                 g_Label_Defs_Extent*sizeof(label_def_t));
         if (g_Label_Defs == NULL) 
         {
@@ -140,12 +140,12 @@ static void add_label_def(char *label)
     g_Num_Label_Defs++;
 }
 
-static void add_label_ref(char *label)
+static void add_label_ref(const char *label)
 {
     if (g_Num_Label_Refs >= g_Label_Refs_Extent)
     {
         g_Label_Refs_Extent += 50;
-        g_Label_Refs = realloc(g_Label_Refs, 
+        g_Label_Refs = (label_def_t*)realloc(g_Label_Refs, 
                 g_Label_Refs_Extent*sizeof(label_def_t));
         if (g_Label_Refs == NULL) 
         {
@@ -171,7 +171,7 @@ static void add_label_ref(char *label)
     g_Num_Label_Refs++;
 }
 
-static label_def_t *get_label_def(char *label)
+static label_def_t *get_label_def(const char *label)
 {
     int ii;
 
@@ -299,11 +299,11 @@ static void Add_File(char *filename)
     if (g_Num_Files >= g_Files_Extent)
     {
         g_Files_Extent += 20;
-        g_File_List = realloc(g_File_List, sizeof(char **)*g_Files_Extent);
+        g_File_List = (char**)realloc(g_File_List, sizeof(char **)*g_Files_Extent);
         assert(g_File_List != NULL);
     }
 
-    g_File_List[g_Num_Files] = malloc(strlen(filename)+1);
+    g_File_List[g_Num_Files] = (char*)malloc(strlen(filename)+1);
     strcpy(g_File_List[g_Num_Files], filename);
     g_Num_Files++;
 }
@@ -392,7 +392,7 @@ static void Process_Args(int argc, char **argv)
     }
 }
 
-static int32_t get_op_index(char *op_name)
+static int32_t get_op_index(const char *op_name)
 {
     int32_t ii;
     for (ii=0; ii<NUM_OPCODES; ii++)
@@ -587,7 +587,7 @@ static void process_asm(char *line)
     }
 }
 
-static char *make_filename(char *in_filename, char *extension)
+static char *make_filename(char *in_filename, const char *extension)
 {
     static char out_filename[256];
     FILE *bin_file;
@@ -731,7 +731,7 @@ static int process_file(char *filename, FILE *listing)
     return 0;
 }
 
-static void update_single_vector(int offset, char *name)
+static void update_single_vector(int offset, const char *name)
 {
     int32_t label_address;
     label_def_t *label_def;

--- a/interp/stackl.c
+++ b/interp/stackl.c
@@ -90,7 +90,6 @@ void Process_Args(int argc, char **argv)
 }
 int main(int argc, char **argv)
 {
-
     int result;
 
     Process_Args(argc, argv);

--- a/interp/stackl.c
+++ b/interp/stackl.c
@@ -90,6 +90,7 @@ void Process_Args(int argc, char **argv)
 }
 int main(int argc, char **argv)
 {
+
     int result;
 
     Process_Args(argc, argv);

--- a/interp/vmem.c
+++ b/interp/vmem.c
@@ -12,7 +12,7 @@ static int  Memory_Size = DEFAULT_MEMORY_SIZE;
 static FILE *Mem_Log = NULL;
 static int Log_Enabled = 0;
 //***************************************
-static void write_log(int32_t address, int32_t value, char *label)
+static void write_log(int32_t address, int32_t value, const char *label)
 {
     if (Log_Enabled)
     {


### PR DESCRIPTION
Basically g++ was complaining about a lot of implicit type casting. Added explicit type casting means the interpreter now compiles in g++ with no warnings and -Wall