### PR TITLE
added cstdint header

### DIFF
--- a/interp/dbg/string_utils.h
+++ b/interp/dbg/string_utils.h
@@ -7,6 +7,7 @@ using std::string;
 #include <functional>
 #include <cctype>
 #include <locale>
+#include <cstdint>
 
 class string_utils
 {


### PR DESCRIPTION
Adds a missing dependency, that may be already included on different platforms. Without this change the code doesn't compile on my machine.