### PR TITLE
Formatted error messages

### DIFF
--- a/compiler/stackl.y
+++ b/compiler/stackl.y
@@ -56,7 +56,7 @@
 %token  AND OR
 %token  SIZEOF
 %token  INC DEC
-%token  PLUS_EQ MINUS_EQ TIMES_EQ DIVIDE_EQ MOD_EQ AND_EQ OR_EQ XOR_EQ 
+%token  PLUS_EQ MINUS_EQ TIMES_EQ DIVIDE_EQ MOD_EQ AND_EQ OR_EQ XOR_EQ
 %token  LEFT_EQ RIGHT_EQ
 %token  PTR LEFT RIGHT
 %token  ASM ASM2
@@ -115,7 +115,7 @@
 %type <expr>            lval
 %%
 
-program: global_decls           { $$ = $1; 
+program: global_decls           { $$ = $1;
                                   yyast_root = $$;
                                   if (yynerrs == 0)
                                   {
@@ -131,8 +131,8 @@ program: global_decls           { $$ = $1;
 block:      open stmts close
             { $$ = $2; }
         | '{' '}'
-            { 
-                $$ = new cStmtsList(new cNopStmt()); 
+            {
+                $$ = new cStmtsList(new cNopStmt());
                 if ($$->HasSemanticError()) YYERROR;
             }
 open:   '{'
@@ -142,20 +142,20 @@ close:  '}'
             { $$ = symbolTableRoot->DecreaseScope(); }
 
 decls:      decls decl
-            { 
-                $$ = $1; $$->AddNode($2); 
+            {
+                $$ = $1; $$->AddNode($2);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   decl
-            { 
-                $$ = new cDeclsList($1); 
+            {
+                $$ = new cDeclsList($1);
                 if ($$->HasSemanticError()) YYERROR;
             }
 decl:       var_decl ';'
             { $$ = $1; }
         |   var_decl '=' expr ';'
             { $1->SetInit($3);
-              $$ = $1; 
+              $$ = $1;
             }
         |   struct_decl ';'
             { $$ = $1; }
@@ -164,14 +164,14 @@ decl:       var_decl ';'
         |   error ';'
             { $$ = NULL; }
 
-var_decl:   type IDENTIFIER 
-            { 
-                $$ = new cVarDecl($1, $2); 
+var_decl:   type IDENTIFIER
+            {
+                $$ = new cVarDecl($1, $2);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   var_decl '[' constant_expression ']'
-            { 
-                $$ = new cVarDecl($1, $3); 
+            {
+                $$ = new cVarDecl($1, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   func_pointer
@@ -179,62 +179,62 @@ var_decl:   type IDENTIFIER
         | STRUCT type IDENTIFIER
             {
                 $$ = new cVarDecl($2, $3, true);
-                if ($$->HasSemanticError()) YYERROR; 
+                if ($$->HasSemanticError()) YYERROR;
             }
 
 type:   type '*'
-            { 
-                $$ = cPointerType::PointerType($1); 
+            {
+                $$ = cPointerType::PointerType($1);
                 if ($$->HasSemanticError()) YYERROR;
             }
         | TYPE_ID
-            { 
-                $$ = dynamic_cast<cTypeDecl*>($1->GetDecl()); 
+            {
+                $$ = dynamic_cast<cTypeDecl*>($1->GetDecl());
                 if ($$->HasSemanticError()) YYERROR;
             }
 
 // Added by Joe
-struct_decl:  struct_header open decls close 
+struct_decl:  struct_header open decls close
                 {
                     $$ = $1;
                     $$->AddDecls($2, $3);
                 }
 // Added by Joe
-struct_header:  STRUCT IDENTIFIER 
+struct_header:  STRUCT IDENTIFIER
             {
                 $$ = new cStructType($2);
             }
-            | STRUCT 
+            | STRUCT
             {
                 $$ = new cStructType(nullptr);;
             }
-global_decls: global_decls global_decl  
-            { 
-                $$ = $1; $$->AddNode($2); 
+global_decls: global_decls global_decl
+            {
+                $$ = $1; $$->AddNode($2);
                 if ($$->HasSemanticError()) YYERROR;
             }
         | global_decl
-            { 
-                $$ = new cDeclsList($1); 
+            {
+                $$ = new cDeclsList($1);
                 if ($$->HasSemanticError()) YYERROR;
             }
 
-typedef:  TYPEDEF type IDENTIFIER 
+typedef:  TYPEDEF type IDENTIFIER
             { $$ = new cTypedef($2, $3); }
-        | TYPEDEF struct_decl IDENTIFIER 
+        | TYPEDEF struct_decl IDENTIFIER
             { $$ = new cTypedef($2, $3); }
 global_decl: func_decl
             { $$ = $1; }
         | STATIC func_decl
             {   $2->SetStatic();
-                $$ = $2; 
+                $$ = $2;
             }
         | struct_decl ';'
             { $$ = $1; }
         | typedef ';'
             { $$ = $1; }
         | CONST type IDENTIFIER '=' constant_expression ';'
-            { 
+            {
                 cVarDecl *var = new cVarDecl($2, $3);
                 var->SetInit($5);
                 var->SetGlobal();
@@ -244,8 +244,8 @@ global_decl: func_decl
                 if ($$->HasSemanticError()) YYERROR;
             }
         | DEFINE IDENTIFIER INT_VAL
-            { 
-                cTypeDecl *type = 
+            {
+                cTypeDecl *type =
                     symbolTableRoot->Lookup("int")->GetDecl()->GetType();
                 cVarDecl *var = new cVarDecl(type, $2);
                 var->SetInit(new cIntExpr($3));
@@ -256,8 +256,8 @@ global_decl: func_decl
                 if ($$->HasSemanticError()) YYERROR;
             }
         | DEFINE IDENTIFIER '-' INT_VAL
-            { 
-                cTypeDecl *type = 
+            {
+                cTypeDecl *type =
                     symbolTableRoot->Lookup("int")->GetDecl()->GetType();
                 cVarDecl *var = new cVarDecl(type, $2);
                 var->SetInit(new cIntExpr(-$4));
@@ -268,95 +268,95 @@ global_decl: func_decl
                 if ($$->HasSemanticError()) YYERROR;
             }
         | EXTERN var_decl ';'
-            { 
+            {
                 $2->SetGlobal();
                 $2->SetExtern();
-                $$ = $2; 
+                $$ = $2;
             }
         | STATIC var_decl ';'
-            { 
+            {
                 $2->SetGlobal();
                 $2->SetStatic();
-                $$ = $2; 
+                $$ = $2;
             }
         | var_decl ';'
-            { 
+            {
                 $1->SetGlobal();
-                $$ = $1; 
+                $$ = $1;
             }
         |   PRAGMA ONCE { $$ = new cPragma("once", "");
-                          if (process_once()) 
+                          if (process_once())
                           {
                               yyerror("'#pragma once' in main source file");
-                              YYABORT; 
+                              YYABORT;
                           }
                         }
-        |   PRAGMA INTERRUPT IDENTIFIER 
-                        { 
+        |   PRAGMA INTERRUPT IDENTIFIER
+                        {
                             $$ = new cPragma("interrupt", $3->Name());
-                            symbolTableRoot->InsertRoot("$$interrupt", $3); 
+                            symbolTableRoot->InsertRoot("$$interrupt", $3);
                         }
-        |   PRAGMA SYSTRAP IDENTIFIER 
-                        { 
+        |   PRAGMA SYSTRAP IDENTIFIER
+                        {
                             $$ = new cPragma("systrap", $3->Name());
-                            symbolTableRoot->InsertRoot("$$systrap", $3); 
+                            symbolTableRoot->InsertRoot("$$systrap", $3);
                         }
-        |   PRAGMA STARTUP IDENTIFIER 
+        |   PRAGMA STARTUP IDENTIFIER
                         {
                             $$ = new cPragma("startup", $3->Name());
-                            symbolTableRoot->InsertRoot("$$startup", $3); 
+                            symbolTableRoot->InsertRoot("$$startup", $3);
                         }
-        |   PRAGMA FEATURE IDENTIFIER 
+        |   PRAGMA FEATURE IDENTIFIER
                         {
                             $$ = new cPragma("feature", $3->Name());
-                            string feature = "$$feature" + 
+                            string feature = "$$feature" +
                                 std::to_string(g_Feature++);
-                            symbolTableRoot->InsertRoot(feature, $3); 
+                            symbolTableRoot->InsertRoot(feature, $3);
                         }
-        |   PRAGMA LIBRARY STRING_LIT 
+        |   PRAGMA LIBRARY STRING_LIT
                         {
                             $$ = new cPragma("library", $3);
                         }
-        |   PRAGMA STACK_SIZE INT_VAL 
+        |   PRAGMA STACK_SIZE INT_VAL
                         {
                             $$ = new cPragma("stack_size", std::to_string($3));
                             cSymbol *size = new cSymbol(std::to_string($3));
-                            symbolTableRoot->InsertRoot( "$$stack_size", size); 
+                            symbolTableRoot->InsertRoot( "$$stack_size", size);
                         }
         | error ';'
             { $$ = NULL; }
 func_decl:  func_header ';'
-            { 
-                $$ = $1; 
+            {
+                $$ = $1;
                 symbolTableRoot->DecreaseScope();
             }
         |   func_header '{' stmts '}'
-            { 
+            {
                 $1->AddStatements($3);
-                $$ = $1; 
+                $$ = $1;
                 if ($$->HasSemanticError()) YYERROR;
                 symbolTableRoot->DecreaseScope();
             }
         |   func_header '{' '}'
-            { 
+            {
                 $1->AddStatements( new cStmtsList(new cNopStmt()) );
-                $$ = $1; 
+                $$ = $1;
                 if ($$->HasSemanticError()) YYERROR;
                 symbolTableRoot->DecreaseScope();
             }
 
-func_header:  func_prefix paramspec_list ')' 
-            { 
+func_header:  func_prefix paramspec_list ')'
+            {
                 $1->AddParams($2);
-                $$ = $1; 
+                $$ = $1;
                 if ($$->HasSemanticError()) YYERROR;
             }
         |     func_prefix ')'
             { $$ = $1; }
 func_prefix: type IDENTIFIER '('
-            { 
+            {
                 $$ = new cFuncDecl($1, $2);
-                symbolTableRoot->IncreaseScope(); 
+                symbolTableRoot->IncreaseScope();
                 if ($$->HasSemanticError()) YYERROR;
             }
 func_pointer: type '(' '*' IDENTIFIER ')' '(' paramspec_list ')'
@@ -364,15 +364,15 @@ func_pointer: type '(' '*' IDENTIFIER ')' '(' paramspec_list ')'
             | type '(' '*' IDENTIFIER ')' '(' ')'
             { semantic_error("Function pointers not implemented", yylineno); YYERROR; }
 
-paramspec_list:     
-            paramspec_list',' paramspec 
-            { 
-                $$ = $1; $$->AddNode($3); 
+paramspec_list:
+            paramspec_list',' paramspec
+            {
+                $$ = $1; $$->AddNode($3);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   paramspec
-            { 
-                $$ = new cDeclsList($1); 
+            {
+                $$ = new cDeclsList($1);
                 if ($$->HasSemanticError()) YYERROR;
             }
         /*
@@ -383,66 +383,66 @@ paramspec:  var_decl
             { $$ = $1; }
 
 stmts:      stmts stmt
-            { 
-                $$ = $1; $$->AddNode($2); 
+            {
+                $$ = $1; $$->AddNode($2);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   stmt
-            { 
-                $$ = new cStmtsList($1); 
+            {
+                $$ = new cStmtsList($1);
                 if ($$->HasSemanticError()) YYERROR;
             }
 
 stmt:       decl
             { $$ = $1; }
         |   ';'
-            { 
-                $$ = new cNopStmt(); 
+            {
+                $$ = new cNopStmt();
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   IF '(' expr ')' stmt ELSE stmt
-            { 
-                $$ = new cIfStmt($3, $5, $7); 
+            {
+                $$ = new cIfStmt($3, $5, $7);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   IF '(' expr ')' stmt
-            { 
-                $$ = new cIfStmt($3, $5, NULL); 
+            {
+                $$ = new cIfStmt($3, $5, NULL);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   FOR '(' expr ';' expr ';' expr ')' stmt
-            { 
-                $$ = new cForStmt($3, $5, $7, $9); 
+            {
+                $$ = new cForStmt($3, $5, $7, $9);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   WHILE '(' expr ')' stmt
-            { 
-                $$ = new cWhileStmt($3, $5); 
+            {
+                $$ = new cWhileStmt($3, $5);
                 if ($$->HasSemanticError()) YYERROR;
             }
-        |   DO stmt WHILE '(' expr ')' ';' 
-            { 
-                $$ = new cDoWhileStmt($5, $2); 
+        |   DO stmt WHILE '(' expr ')' ';'
+            {
+                $$ = new cDoWhileStmt($5, $2);
                 if ($$->HasSemanticError()) YYERROR;
             }
 
         |   SWITCH '(' expr ')' stmt
             { semantic_error("Not implemented " + std::to_string(__LINE__), yylineno); }
         |   expr ';'
-            { 
-                $$ = new cExprStmt($1); 
+            {
+                $$ = new cExprStmt($1);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   block
             { $$ = $1; }
         |   RETURN expr ';'
-            { 
-                $$ = new cReturnStmt($2); 
+            {
+                $$ = new cReturnStmt($2);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   RETURN ';'
-            { 
-                $$ = new cReturnStmt(NULL); 
+            {
+                $$ = new cReturnStmt(NULL);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   BREAK ';'
@@ -454,54 +454,54 @@ stmt:       decl
         |   asm_stmt ';'
             { $$ = $1; }
 
-asm_stmt : ASM '(' string_lit ')' 
-            { 
-                $$ = new cAsmNode($3, NULL); 
+asm_stmt : ASM '(' string_lit ')'
+            {
+                $$ = new cAsmNode($3, NULL);
                 if ($$->HasSemanticError()) YYERROR;
             }
         | ASM '(' string_lit ',' params ')'
-            { 
-                $$ = new cAsmNode($3, $5); 
+            {
+                $$ = new cAsmNode($3, $5);
                 if ($$->HasSemanticError()) YYERROR;
             }
-        | ASM2 '(' string_lit ',' constant_expression ')' 
-            { 
-                $$ = new cAsmNode($3, $5->ConstValue(), NULL); 
+        | ASM2 '(' string_lit ',' constant_expression ')'
+            {
+                $$ = new cAsmNode($3, $5->ConstValue(), NULL);
                 if ($$->HasSemanticError()) YYERROR;
             }
         | ASM2 '(' string_lit  ',' constant_expression ',' params ')'
-            { 
-                $$ = new cAsmNode($3, $5->ConstValue(), $7); 
+            {
+                $$ = new cAsmNode($3, $5->ConstValue(), $7);
                 if ($$->HasSemanticError()) YYERROR;
             }
 lval:     unary_expression
             { $$ = $1; }
 params:     params',' assignment_expression
-            { 
-                $$ = $1; $$->AddNode($3); 
+            {
+                $$ = $1; $$->AddNode($3);
                 if ($$->HasSemanticError()) YYERROR;
             }
         |   assignment_expression
-            { 
-                $$ = new cParams($1); 
+            {
+                $$ = new cParams($1);
                 if ($$->HasSemanticError()) YYERROR;
             }
 
 string_lit: STRING_LIT
-            { 
-                $$ = new cStringLit($1); 
+            {
+                $$ = new cStringLit($1);
                 if ($$->HasSemanticError()) YYERROR;
             }
 
 primary_expression
 	: IDENTIFIER
-            { 
-                $$ = new cPlainVarRef($1); 
+            {
+                $$ = new cPlainVarRef($1);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| INT_VAL
-            { 
-                $$ = new cIntExpr($1); 
+            {
+                $$ = new cIntExpr($1);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| string_lit
@@ -515,38 +515,38 @@ postfix_expression
 	: primary_expression
             { $$ = $1; }
 	| postfix_expression '[' expr ']'
-            { 
-                $$ = new cArrayRef($1, $3); 
+            {
+                $$ = new cArrayRef($1, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| postfix_expression '(' params ')'
-            { 
-                $$ = new cFuncCall($1, $3); 
+            {
+                $$ = new cFuncCall($1, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
-        | postfix_expression '(' ')' 
-            { 
-                $$ = new cFuncCall($1, NULL); 
+        | postfix_expression '(' ')'
+            {
+                $$ = new cFuncCall($1, NULL);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| postfix_expression '.' IDENTIFIER
-            { 
+            {
                 $$ = new cStructRef($1, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| postfix_expression PTR IDENTIFIER
-            { 
+            {
                 $$ = new cStructDeref($1, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| postfix_expression INC
-            { 
-                $$ = new cPostfixExpr($1, '+'); 
+            {
+                $$ = new cPostfixExpr($1, '+');
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| postfix_expression DEC
-            { 
-                $$ = new cPostfixExpr($1, '-'); 
+            {
+                $$ = new cPostfixExpr($1, '-');
                 if ($$->HasSemanticError()) YYERROR;
             }
 	;
@@ -555,49 +555,49 @@ unary_expression
 	: postfix_expression
             { $$ = $1; }
 	| INC unary_expression
-            { 
-                $$ = new cPrefixExpr('+', $2); 
+            {
+                $$ = new cPrefixExpr('+', $2);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| DEC unary_expression
-            { 
-                $$ = new cPrefixExpr('-', $2); 
+            {
+                $$ = new cPrefixExpr('-', $2);
                 if ($$->HasSemanticError()) YYERROR;
             }
         | '+' cast_expression
             { $$ = $2; }
         | '-' cast_expression
-            { 
-                $$ = new cUnaryExpr('-', $2); 
+            {
+                $$ = new cUnaryExpr('-', $2);
                 if ($$->HasSemanticError()) YYERROR;
             }
         | '~' cast_expression
-            { 
-                $$ = new cUnaryExpr('~', $2); 
+            {
+                $$ = new cUnaryExpr('~', $2);
                 if ($$->HasSemanticError()) YYERROR;
             }
         | '!' cast_expression
-            { 
-                $$ = new cUnaryExpr('!', $2); 
+            {
+                $$ = new cUnaryExpr('!', $2);
                 if ($$->HasSemanticError()) YYERROR;
             }
         | '*' cast_expression
-            { 
-                $$ = new cPointerDeref($2); 
+            {
+                $$ = new cPointerDeref($2);
                 if ($$->HasSemanticError()) YYERROR;
             }
         | '&' cast_expression
-            { 
+            {
                 $$ = new cAddressExpr($2);
                 if ($$->HasSemanticError()) YYERROR;
             }
-	| SIZEOF unary_expression 
-            { 
+	| SIZEOF unary_expression
+            {
                 $$ = new cSizeofExpr($2);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| SIZEOF '(' type ')'
-            { 
+            {
                 $$ = new cSizeofExpr($3);
                 if ($$->HasSemanticError()) YYERROR;
             }
@@ -606,7 +606,7 @@ unary_expression
 cast_expression
 	: unary_expression
             { $$ = $1; }
-	| '(' type ')' cast_expression      
+	| '(' type ')' cast_expression
             { $$ = new cCastExpr($2, $4); }
 	;
 
@@ -614,18 +614,18 @@ multiplicative_expression
 	: cast_expression
             { $$ = $1; }
 	| multiplicative_expression '*' cast_expression
-            { 
-                $$ = new cBinaryExpr($1, '*', $3); 
+            {
+                $$ = new cBinaryExpr($1, '*', $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| multiplicative_expression '/' cast_expression
-            { 
-                $$ = new cBinaryExpr($1, '/', $3); 
+            {
+                $$ = new cBinaryExpr($1, '/', $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| multiplicative_expression '%' cast_expression
-            { 
-                $$ = new cBinaryExpr($1, '%', $3); 
+            {
+                $$ = new cBinaryExpr($1, '%', $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	;
@@ -634,13 +634,13 @@ additive_expression
 	: multiplicative_expression
             { $$ = $1; }
 	| additive_expression '+' multiplicative_expression
-            { 
-                $$ = new cBinaryExpr($1, '+', $3); 
+            {
+                $$ = new cBinaryExpr($1, '+', $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| additive_expression '-' multiplicative_expression
-            { 
-                $$ = new cBinaryExpr($1, '-', $3); 
+            {
+                $$ = new cBinaryExpr($1, '-', $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	;
@@ -649,13 +649,13 @@ shift_expression
 	: additive_expression
             { $$ = $1; }
 	| shift_expression LEFT additive_expression
-            { 
-                $$ = new cBinaryExpr($1, LEFT, $3); 
+            {
+                $$ = new cBinaryExpr($1, LEFT, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| shift_expression RIGHT additive_expression
-            { 
-                $$ = new cBinaryExpr($1, RIGHT, $3); 
+            {
+                $$ = new cBinaryExpr($1, RIGHT, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	;
@@ -664,23 +664,23 @@ relational_expression
 	: shift_expression
             { $$ = $1; }
 	| relational_expression '<' shift_expression
-            { 
-                $$ = new cBinaryExpr($1, '<', $3); 
+            {
+                $$ = new cBinaryExpr($1, '<', $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| relational_expression '>' shift_expression
-            { 
-                $$ = new cBinaryExpr($1, '>', $3); 
+            {
+                $$ = new cBinaryExpr($1, '>', $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| relational_expression LE shift_expression
-            { 
-                $$ = new cBinaryExpr($1, LE, $3); 
+            {
+                $$ = new cBinaryExpr($1, LE, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| relational_expression GE shift_expression
-            { 
-                $$ = new cBinaryExpr($1, GE, $3); 
+            {
+                $$ = new cBinaryExpr($1, GE, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	;
@@ -689,13 +689,13 @@ equality_expression
 	: relational_expression
             { $$ = $1; }
 	| equality_expression EQ relational_expression
-            { 
-                $$ = new cBinaryExpr($1, EQ, $3); 
+            {
+                $$ = new cBinaryExpr($1, EQ, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	| equality_expression NE relational_expression
-            { 
-                $$ = new cBinaryExpr($1, NE, $3); 
+            {
+                $$ = new cBinaryExpr($1, NE, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	;
@@ -704,8 +704,8 @@ and_expression
 	: equality_expression
             { $$ = $1; }
 	| and_expression '&' equality_expression
-            { 
-                $$ = new cBinaryExpr($1, '&', $3); 
+            {
+                $$ = new cBinaryExpr($1, '&', $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	;
@@ -714,8 +714,8 @@ exclusive_or_expression
 	: and_expression
             { $$ = $1; }
 	| exclusive_or_expression '^' and_expression
-            { 
-                $$ = new cBinaryExpr($1, '^', $3); 
+            {
+                $$ = new cBinaryExpr($1, '^', $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	;
@@ -724,8 +724,8 @@ inclusive_or_expression
 	: exclusive_or_expression
             { $$ = $1; }
 	| inclusive_or_expression '|' exclusive_or_expression
-            { 
-                $$ = new cBinaryExpr($1, '|', $3); 
+            {
+                $$ = new cBinaryExpr($1, '|', $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	;
@@ -734,8 +734,8 @@ logical_and_expression
 	: inclusive_or_expression
             { $$ = $1; }
 	| logical_and_expression AND inclusive_or_expression
-            { 
-                $$ = new cShortCircuitExpr($1, AND, $3, false); 
+            {
+                $$ = new cShortCircuitExpr($1, AND, $3, false);
                 if ($$->HasSemanticError()) YYERROR;
             }
 	;
@@ -744,8 +744,8 @@ logical_or_expression
 	: logical_and_expression
             { $$ = $1; }
 	| logical_or_expression OR logical_and_expression
-            { 
-                $$ = new cShortCircuitExpr($1, OR, $3, true); 
+            {
+                $$ = new cShortCircuitExpr($1, OR, $3, true);
                 if ($$->HasSemanticError()) YYERROR;
             }
 
@@ -761,7 +761,7 @@ conditional_expression
 
 constant_expression
         : conditional_expression
-            { 
+            {
                 $$ = $1;
                 if (!$$->IsConst())
                 {
@@ -774,68 +774,68 @@ assignment_expression
         : conditional_expression
             { $$ = $1; }
         | lval '=' expr
-            { 
-                $$ = new cAssignExpr($1, $3); 
+            {
+                $$ = new cAssignExpr($1, $3);
                 if ($$->HasSemanticError()) YYERROR;
             }
         | lval '=' asm_stmt
             { $$ = new cAssignExpr($1, $3); }
         | lval PLUS_EQ expr
-            { 
-                $$ = new cAssignExpr($1, new cBinaryExpr($1, '+', $3)); 
+            {
+                $$ = new cAssignExpr($1, new cBinaryExpr($1, '+', $3));
                 if ($$->HasSemanticError()) YYERROR;
             }
         | lval MINUS_EQ expr
-            { 
-                $$ = new cAssignExpr($1, new cBinaryExpr($1, '-', $3)); 
+            {
+                $$ = new cAssignExpr($1, new cBinaryExpr($1, '-', $3));
                 if ($$->HasSemanticError()) YYERROR;
             }
         | lval TIMES_EQ expr
-            { 
-                $$ = new cAssignExpr($1, new cBinaryExpr($1, '*', $3)); 
+            {
+                $$ = new cAssignExpr($1, new cBinaryExpr($1, '*', $3));
                 if ($$->HasSemanticError()) YYERROR;
             }
         | lval DIVIDE_EQ expr
-            { 
-                $$ = new cAssignExpr($1, new cBinaryExpr($1, '/', $3)); 
+            {
+                $$ = new cAssignExpr($1, new cBinaryExpr($1, '/', $3));
                 if ($$->HasSemanticError()) YYERROR;
             }
         | lval MOD_EQ expr
-            { 
-                $$ = new cAssignExpr($1, new cBinaryExpr($1, '%', $3)); 
+            {
+                $$ = new cAssignExpr($1, new cBinaryExpr($1, '%', $3));
                 if ($$->HasSemanticError()) YYERROR;
             }
         | lval OR_EQ expr
-            { 
-                $$ = new cAssignExpr($1, new cBinaryExpr($1, '|', $3)); 
+            {
+                $$ = new cAssignExpr($1, new cBinaryExpr($1, '|', $3));
                 if ($$->HasSemanticError()) YYERROR;
             }
         | lval AND_EQ expr
-            { 
-                $$ = new cAssignExpr($1, new cBinaryExpr($1, '&', $3)); 
+            {
+                $$ = new cAssignExpr($1, new cBinaryExpr($1, '&', $3));
                 if ($$->HasSemanticError()) YYERROR;
             }
         | lval XOR_EQ expr
-            { 
-                $$ = new cAssignExpr($1, new cBinaryExpr($1, '^', $3)); 
+            {
+                $$ = new cAssignExpr($1, new cBinaryExpr($1, '^', $3));
                 if ($$->HasSemanticError()) YYERROR;
             }
         | lval LEFT_EQ expr
-            { 
-                $$ = new cAssignExpr($1, new cBinaryExpr($1, LEFT, $3)); 
+            {
+                $$ = new cAssignExpr($1, new cBinaryExpr($1, LEFT, $3));
                 if ($$->HasSemanticError()) YYERROR;
             }
         | lval RIGHT_EQ expr
-            { 
-                $$ = new cAssignExpr($1, new cBinaryExpr($1, RIGHT, $3)); 
+            {
+                $$ = new cAssignExpr($1, new cBinaryExpr($1, RIGHT, $3));
                 if ($$->HasSemanticError()) YYERROR;
             }
 expr: assignment_expression
             { $$ = $1; }
         /*
         | expr ',' assignment_expression
-            { 
-                semantic_error("Not implemented " + std::to_string(__LINE__), yylineno); 
+            {
+                semantic_error("Not implemented " + std::to_string(__LINE__), yylineno);
                 YYERROR;
             }
 	;
@@ -852,9 +852,9 @@ int yyerror(const char *msg)
 }
 int semantic_error(std::string msg, int line)
 {
-    std::cerr << "ERROR: " << msg << " on line " << line 
-        << " of " << yycurrentfile << "\n";
-    
+    std::cerr << yycurrentfile << ":" << line << ": error: "
+        << msg << "\n";
+
     yynerrs++;
 
     return 0;

--- a/compiler/stackl.y
+++ b/compiler/stackl.y
@@ -845,8 +845,8 @@ expr: assignment_expression
 
 int yyerror(const char *msg)
 {
-    std::cerr << "ERROR: " << msg << " at symbol "
-        << yytext << " on line " << yylineno << " of " << yycurrentfile << "\n";
+    std::cerr << yycurrentfile << ":" << yylineno << ": error: "
+        << msg << " at symbol " << yytext << "\n";
 
     return 0;
 }

--- a/test/test45.correct
+++ b/test/test45.correct
@@ -1,2 +1,2 @@
-ERROR: lval must be a variable that's not a struct nor an array on line 20 of test/test45.c
+test/test45.c:20: error: lval must be a variable that's not a struct nor an array
 1 Errors in compile

--- a/test/test55.correct
+++ b/test/test55.correct
@@ -1,3 +1,3 @@
-ERROR: Return statement type is incompatible with function declaration on line 4 of test/test55.c
-ERROR: Return statement type is incompatible with function declaration on line 9 of test/test55.c
+test/test55.c:4: error: Return statement type is incompatible with function declaration
+test/test55.c:9: error: Return statement type is incompatible with function declaration
 2 Errors in compile

--- a/test/test56.correct
+++ b/test/test56.correct
@@ -1,2 +1,2 @@
-ERROR: Source produced no output  on line 0 of test/test56.c
+test/test56.c:0: error: Source produced no output
 


### PR DESCRIPTION
smart editors such as VSCode can now jump to syntax errors with ctrl+click

Also deleted some trailing whitespace (unintentionally from editor extension)