### PR TITLE
Reformatted error messages

### DIFF
--- a/compiler/stackl.y
+++ b/compiler/stackl.y
@@ -845,15 +845,15 @@ expr: assignment_expression
 
 int yyerror(const char *msg)
 {
-    std::cerr << "ERROR: " << msg << " at symbol "
-        << yytext << " on line " << yylineno << " of " << yycurrentfile << "\n";
+    std::cerr << yycurrentfile << ":" << yylineno << ": error:"
+        << msg << " at symbol " << yytext << "\n";
 
     return 0;
 }
 int semantic_error(std::string msg, int line)
 {
-    std::cerr << "ERROR: " << msg << " on line " << line 
-        << " of " << yycurrentfile << "\n";
+    std::cerr << yycurrentfile << ":" << line << ": error: "
+        << msg << "\n";
     
     yynerrs++;
 

--- a/test/test45.correct
+++ b/test/test45.correct
@@ -1,2 +1,2 @@
-ERROR: lval must be a variable that's not a struct nor an array on line 20 of test/test45.c
+test/test45/c:20: error: lval must be a variable that's not a struct nor an array
 1 Errors in compile

--- a/test/test45.correct
+++ b/test/test45.correct
@@ -1,2 +1,2 @@
-test/test45/c:20: error: lval must be a variable that's not a struct nor an array
+test/test45.c:20: error: lval must be a variable that's not a struct nor an array
 1 Errors in compile

--- a/test/test55.correct
+++ b/test/test55.correct
@@ -1,3 +1,3 @@
-ERROR: Return statement type is incompatible with function declaration on line 4 of test/test55.c
-ERROR: Return statement type is incompatible with function declaration on line 9 of test/test55.c
+test/test55.c:4: error: Return statement type is incompatible with function declaration
+test/test55.c:9: error: Return statement type is incompatible with function declaration
 2 Errors in compile

--- a/test/test56.correct
+++ b/test/test56.correct
@@ -1,2 +1,2 @@
-ERROR: Source produced no output  on line 0 of test/test56.c
+test/test56.c:0: error: Source produced no output
 


### PR DESCRIPTION
This error format allows smart editors to link and jump to problem line.