### PR TITLE
BUGFIX: memcmp prototype consistence

### DIFF
--- a/library/string.c
+++ b/library/string.c
@@ -241,11 +241,13 @@ void *memset(void *buff, int val, int size)
     return buff;
 }
 
-int memcmp(char *str1, char *str2, int size)
+int memcmp(void *s1, void *s2, int n)
 {
+    char* str1 = (char*)s1;
+    char* str2 = (char*)s2;
     int index;
     int result;
-    while (size--)
+    while (n--)
     {
         result = *str1 - *str2;
         if (result != 0) return result;

--- a/library/string.h
+++ b/library/string.h
@@ -12,4 +12,4 @@ char *itostr(int value, char *str);
 char *xtostr(int value, char *str);
 void *memcpy(void *dest, void *src, int size);
 void *memset(void *buff, int val, int size);
-void *memcmp(void *dest, void *src, int size);
+int memcmp(void *s1, void *s2, int n);


### PR DESCRIPTION
Fixes #23, so that `memcmp` is prototype is consistent between source and header.